### PR TITLE
Reorder statements to fix missing resource error

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'ops+cookbooks@optimiscorp.com'
 license 'Apache 2.0'
 description 'Library cookbook to configure Rubygems.'
 long_description 'Library cookbook to configure Rubygems.'
-version '1.1.0'
+version '1.1.1'
 
 depends 'poise', '~> 2.2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,15 +4,14 @@
 #
 # Copyright 2015-2016, Bloomberg Finance L.P.
 #
-
-gemrc_file node['gemrc']['path'] do
-  options node['gemrc']['config']
-  notifies :run, 'ruby_block[reload-gem-configuration]', :delayed
-end.run_action(:create)
-
 arguments = ['--config-file', node['gemrc']['path']].join('=')
 ruby_block 'reload-gem-configuration' do
   action :nothing
   block { Gem.configuration = Gem::ConfigFile.new [arguments] }
   only_if { node['gemrc']['reload'] }
 end
+
+gemrc_file node['gemrc']['path'] do
+  options node['gemrc']['config']
+  notifies :run, 'ruby_block[reload-gem-configuration]', :delayed
+end.run_action(:create)


### PR DESCRIPTION
This fixes the issue where chef converge results in resource missing error.
`resource gemrc_file[/opt/chef/embedded/etc/gemrc] is configured to notify resource ruby_block[reload-gem-configuration] with action run, but ruby_block[reload-gem-configuration] cannot be found in the resource collection. gemrc_file[/opt/chef/embedded/etc/gemrc] is defined in /tmp/kitchen/cache/cookbooks/gemrc/recipes/default.rb:8:in`
cc @johnbellone 
